### PR TITLE
ДЗ №7 сравнение стандартного пакета http и fasthttp под нагрузкой

### DIFF
--- a/07-load-testing/cmd/loadtest/main.go
+++ b/07-load-testing/cmd/loadtest/main.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type RequestConfig struct {
+	URL     string
+	Method  string
+	Headers map[string]string
+	Body    string
+}
+
+type Result struct {
+	Duration time.Duration
+	Status   int
+	Error    error
+}
+
+type Stats struct {
+	TotalRequests int
+	SuccessCount  int
+	ErrorCount    int
+	TotalDuration time.Duration
+	MinDuration   time.Duration
+	MaxDuration   time.Duration
+	StatusCodes   map[int]int
+	mutex         sync.Mutex
+}
+
+func NewStats() *Stats {
+	return &Stats{
+		StatusCodes: make(map[int]int),
+		MinDuration: time.Hour, // Initialize with large value
+	}
+}
+
+func (s *Stats) AddResult(result Result) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.TotalRequests++
+	s.TotalDuration += result.Duration
+
+	if result.Error != nil {
+		s.ErrorCount++
+	} else {
+		s.SuccessCount++
+		s.StatusCodes[result.Status]++
+
+		if result.Duration < s.MinDuration {
+			s.MinDuration = result.Duration
+		}
+		if result.Duration > s.MaxDuration {
+			s.MaxDuration = result.Duration
+		}
+	}
+}
+
+func (s *Stats) Print() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	fmt.Println("\n=== Load Test Results ===")
+	fmt.Printf("Total Requests: %d\n", s.TotalRequests)
+	fmt.Printf("Successful: %d\n", s.SuccessCount)
+	fmt.Printf("Failed: %d\n", s.ErrorCount)
+	fmt.Printf("Average Duration: %v\n", s.TotalDuration/time.Duration(s.TotalRequests))
+	fmt.Printf("Min Duration: %v\n", s.MinDuration)
+	fmt.Printf("Max Duration: %v\n", s.MaxDuration)
+	fmt.Println("Status Codes:")
+	for code, count := range s.StatusCodes {
+		fmt.Printf("  %d: %d\n", code, count)
+	}
+}
+
+func makeRequest(config RequestConfig) Result {
+	start := time.Now()
+	var result Result
+
+	// Create request body if provided
+	var reqBody *bytes.Buffer
+	if config.Body != "" {
+		reqBody = bytes.NewBufferString(config.Body)
+	} else {
+		reqBody = bytes.NewBufferString("")
+	}
+
+	req, err := http.NewRequest(config.Method, config.URL, reqBody)
+	if err != nil {
+		result.Error = err
+		return result
+	}
+
+	// Set headers
+	for key, value := range config.Headers {
+		req.Header.Set(key, value)
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		result.Error = err
+		return result
+	}
+	defer resp.Body.Close()
+
+	// Read response body (optional)
+	_, err = io.ReadAll(resp.Body)
+	if err != nil {
+		result.Error = err
+		return result
+	}
+
+	result.Duration = time.Since(start)
+	result.Status = resp.StatusCode
+	return result
+}
+
+func worker(id int, config RequestConfig, requests chan struct{}, results chan Result, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for range requests {
+		results <- makeRequest(config)
+	}
+}
+
+func loadTest(config RequestConfig, concurrency int, totalRequests int) {
+	requests := make(chan struct{}, totalRequests)
+	results := make(chan Result, totalRequests)
+	stats := NewStats()
+	var wg sync.WaitGroup
+
+	// Create worker pool
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go worker(i, config, requests, results, &wg)
+	}
+
+	// Send requests
+	for i := 0; i < totalRequests; i++ {
+		requests <- struct{}{}
+	}
+	close(requests)
+
+	// Collect results
+	go func() {
+		for result := range results {
+			stats.AddResult(result)
+		}
+	}()
+
+	wg.Wait()
+	close(results)
+
+	stats.Print()
+}
+
+func main() {
+	url := flag.String("url", "", "Target URL to test")
+	method := flag.String("method", "GET", "HTTP method")
+	concurrency := flag.Int("concurrency", 10, "Number of concurrent workers")
+	requests := flag.Int("requests", 100, "Total number of requests")
+	body := flag.String("body", "", "Request body (JSON)")
+	header := flag.String("header", "", "Custom headers (JSON)")
+	flag.Parse()
+
+	if *url == "" {
+		log.Fatal("URL is required")
+	}
+
+	config := RequestConfig{
+		URL:    *url,
+		Method: *method,
+	}
+
+	// Parse headers if provided
+	if *header != "" {
+		var headers map[string]string
+		if err := json.Unmarshal([]byte(*header), &headers); err != nil {
+			log.Fatalf("Invalid header JSON: %v", err)
+		}
+		config.Headers = headers
+	}
+
+	// Set body if provided
+	if *body != "" {
+		config.Body = *body
+	}
+
+	fmt.Printf("Starting load test:\n")
+	fmt.Printf("  URL: %s\n", config.URL)
+	fmt.Printf("  Method: %s\n", config.Method)
+	fmt.Printf("  Concurrency: %d\n", *concurrency)
+	fmt.Printf("  Total Requests: %d\n", *requests)
+	if len(config.Headers) > 0 {
+		fmt.Println("  Headers:", config.Headers)
+	}
+	if config.Body != "" {
+		fmt.Println("  Body:", config.Body)
+	}
+
+	loadTest(config, *concurrency, *requests)
+}

--- a/07-load-testing/go.mod
+++ b/07-load-testing/go.mod
@@ -1,0 +1,11 @@
+module github.com/charlie-wasp/go-masters-2025/load-testing
+
+go 1.24.1
+
+require github.com/valyala/fasthttp v1.62.0
+
+require (
+	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+)

--- a/07-load-testing/go.sum
+++ b/07-load-testing/go.sum
@@ -1,0 +1,10 @@
+github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
+github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.62.0 h1:8dKRBX/y2rCzyc6903Zu1+3qN0H/d2MsxPPmVNamiH0=
+github.com/valyala/fasthttp v1.62.0/go.mod h1:FCINgr4GKdKqV8Q0xv8b+UxPV+H/O5nNFo3D+r54Htg=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=

--- a/07-load-testing/main.go
+++ b/07-load-testing/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/valyala/fasthttp"
+)
+
+const responseText = "Hello to you too!"
+
+func main() {
+	go func() {
+		fasthttpHandler := func(ctx *fasthttp.RequestCtx) {
+			switch string(ctx.Path()) {
+			case "/hello":
+				ctx.WriteString(responseText)
+			default:
+				ctx.Error("Not Found", fasthttp.StatusNotFound)
+			}
+		}
+
+		log.Println("Fasthttp server listening on :8081")
+		if err := fasthttp.ListenAndServe(":8081", fasthttpHandler); err != nil {
+			log.Printf("Fasthttp server error: %v\n", err)
+		}
+	}()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(responseText))
+	})
+
+	log.Println("Standard HTTP server listening on :8080")
+	if err := http.ListenAndServe(":8080", mux); err != nil {
+		log.Printf("Standard server error: %v", err)
+	}
+}


### PR DESCRIPTION
В директории `cmd/loadtest` лежит сгенерированная DeepSeek утилита для нагрузочного тестирования 

_(нормально ли так структурировать директории? насколько я понял, в `cmd` у нас может быть несколько директорий для разных исполняемых файлов)_

Параметр `request` отвечает за кол-во запросов, `concurrency` — за кол-во воркеров, эти запросы отправляющие

Результаты получились такие:

```
##########################
# Стандартная библиотека #
#########################

$ ./loadtest -url http://localhost:8080/hello -requests 1000 -concurrency 50

Starting load test:
  URL: http://localhost:8080/hello
  Method: GET
  Concurrency: 50
  Total Requests: 1000

=== Load Test Results ===
Total Requests: 999
Successful: 999
Failed: 0
Average Duration: 2.443148ms
Min Duration: 64.291µs
Max Duration: 7.998666ms
Status Codes:
  200: 999

############
# fasthttp #
############

$ ./loadtest -url http://localhost:8081/hello -requests 1000 -concurrency 50
Starting load test:
  URL: http://localhost:8081/hello
  Method: GET
  Concurrency: 50
  Total Requests: 1000

=== Load Test Results ===
Total Requests: 999
Successful: 999
Failed: 0
Average Duration: 2.061547ms
Min Duration: 43.834µs
Max Duration: 10.080458ms
Status Codes:
  200: 999

```